### PR TITLE
Removed deprecated SCI_GETSTYLEBITS call for Notepad++ 7.7 update.

### DIFF
--- a/src/NppExport.cpp
+++ b/src/NppExport.cpp
@@ -369,8 +369,7 @@ void fillScintillaData(CurrentScintillaData * csd, int start, int end) {
 	int prevStyle = -1, currentStyle;
 
 	//Mask the styles so any indicators get ignored, else overflow possible
-	int bits = (int)SendMessage(hScintilla, SCI_GETSTYLEBITS, 0, 0);
-	unsigned char mask = 0xFF >> (8-bits);
+	unsigned char mask = 0xFF;
 	for(int i = 0; i < len; i++) {
 		csd->dataBuffer[i*2+1] &= mask;
 	}


### PR DESCRIPTION
Possible fix for #7 

Original code:
`
	int bits = (int)SendMessage(hScintilla, SCI_GETSTYLEBITS, 0, 0);
	unsigned char mask = 0xFF >> (8-bits);
`    

SCI_GETSTYLEBITS [deprecated ](https://www.scintilla.org/ScintillaDoc.html#SCI_GETSTYLEBITS)
It always returned 8, so we use bits=8 and then a shift of 8-8=0 does nothing
    
This should fix for Notepad++ 7.7 above (new Scintilla), as well as stay backward compatible with older Notepad++ < 7.7.

[Further discussion](https://notepad-plus-plus.org/community/topic/17801/plugins-nppexport-lost-color-format-in-version-7-7-7/3)